### PR TITLE
pass context when to simple_json_api render

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ggordon/simple_json_api.git
-  revision: 1347f1450ca789b29e4c6de60a5f09879f30b9a8
+  revision: 5bdc4d0b1c434cc439883f4332b8ea9f13e2f561
   branch: master
   specs:
     simple_json_api (0.0.5)
@@ -52,7 +52,6 @@ GEM
     database_cleaner (1.4.1)
     docile (1.1.5)
     erubis (2.7.0)
-    hike (1.2.3)
     i18n (0.7.0)
     json (1.8.2)
     json-schema (2.5.1)
@@ -60,7 +59,7 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     mime-types (2.4.3)
-    minitest (5.5.1)
+    minitest (5.6.0)
     minitest-rails (2.1.1)
       minitest (~> 5.4)
       railties (~> 4.1)
@@ -97,11 +96,8 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.9.0)
     simplecov-html (0.9.0)
-    sprockets (2.12.3)
-      hike (~> 1.2)
-      multi_json (~> 1.0)
+    sprockets (3.0.1)
       rack (~> 1.0)
-      tilt (~> 1.1, != 1.3.0)
     sprockets-rails (2.2.4)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
@@ -109,7 +105,6 @@ GEM
     sqlite3 (1.3.10)
     thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (1.4.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
 

--- a/lib/simple_json_api/rails/railtie.rb
+++ b/lib/simple_json_api/rails/railtie.rb
@@ -16,7 +16,8 @@ module SimpleJsonApi
             model: object,
             serializer: options[:serializer],
             fields: options[:fields],
-            include: options[:include]
+            include: options[:include],
+            context: { base_url: request.base_url + request.script_name }
           )
         end
 


### PR DESCRIPTION
pass context to simple_json_api render for rendering top-level and resource links
